### PR TITLE
change 'deviance' to '-2*log(L)' in lme4 stats

### DIFF
--- a/R/tidy_stats.lmerMod.r
+++ b/R/tidy_stats.lmerMod.r
@@ -20,8 +20,8 @@ tidy_stats.lmerMod <- function(x, args = NULL) {
       summary$AICtab[["logLik"]], "l"
     )
     statistics <- add_statistic(
-      statistics, "deviance",
-      summary$AICtab[["deviance"]], "D"
+      statistics, "-2*log(L)",
+      summary$AICtab[["-2*log(L)"]], "D"
     )
     statistics <- add_statistic(
       statistics, "residual df",
@@ -282,7 +282,7 @@ tidy_stats.lmerModLmerTest <- function(x, args = NULL) {
       add_statistic("AIC", summary$AICtab[["AIC"]]) |>
       add_statistic("BIC", summary$AICtab[["BIC"]]) |>
       add_statistic("log likelihood", summary$AICtab[["logLik"]], "l") |>
-      add_statistic("deviance", summary$AICtab[["deviance"]], "D") |>
+      add_statistic("-2*log(L)", summary$AICtab[["-2*log(L)"]], "D") |>
       add_statistic("residual df", summary$AICtab[["df.resid"]], "df", "res.")
   }
 

--- a/tests/data/lme4.json
+++ b/tests/data/lme4.json
@@ -162,7 +162,7 @@
             "value": -897.039322
           },
           {
-            "name": "deviance",
+            "name": "-2*log(L)",
             "symbol": "D",
             "value": 1794.078643
           },
@@ -513,7 +513,7 @@
                 "value": -897.039322
               },
               {
-                "name": "deviance",
+                "name": "-2*log(L)",
                 "symbol": "D",
                 "value": 1794.078643
               }
@@ -541,7 +541,7 @@
                 "value": -876.001628
               },
               {
-                "name": "deviance",
+                "name": "-2*log(L)",
                 "symbol": "D",
                 "value": 1752.003255
               },

--- a/tests/data/lmerTest.json
+++ b/tests/data/lmerTest.json
@@ -1173,7 +1173,7 @@
             "value": -875.969672
           },
           {
-            "name": "deviance",
+            "name": "-2*log(L)",
             "symbol": "D",
             "value": 1751.939344
           },
@@ -1468,7 +1468,7 @@
                 "value": -897.039322
               },
               {
-                "name": "deviance",
+                "name": "-2*log(L)",
                 "symbol": "D",
                 "value": 1794.078643
               }
@@ -1496,7 +1496,7 @@
                 "value": -875.969672
               },
               {
-                "name": "deviance",
+                "name": "-2*log(L)",
                 "symbol": "D",
                 "value": 1751.939344
               },

--- a/tests/testthat/test_lme4.R
+++ b/tests/testthat/test_lme4.R
@@ -5,6 +5,7 @@ expected_statistics <- read_stats("../data/lme4.json")
 # lmer() ------------------------------------------------------------------
 
 test_that("lme4 works", {
+  skip_if(packageVersion("lme4") < "1.1.37")
   model <- lme4::lmer(Reaction ~ Days + (1 | Subject), lme4::sleepstudy)
 
   expect_equal_models(
@@ -14,6 +15,7 @@ test_that("lme4 works", {
 })
 
 test_that("lme4 ML works", {
+  skip_if(packageVersion("lme4") < "1.1.37")
   model <- lme4::lmer(Reaction ~ Days + (1 | Subject), lme4::sleepstudy,
     REML = FALSE
   )
@@ -25,6 +27,7 @@ test_that("lme4 ML works", {
 })
 
 test_that("lme4 slopes works", {
+  skip_if(packageVersion("lme4") < "1.1.37")
   model <- lme4::lmer(Reaction ~ Days + (Days || Subject), lme4::sleepstudy)
 
   expect_equal_models(
@@ -36,6 +39,7 @@ test_that("lme4 slopes works", {
 # anova.merMod() ----------------------------------------------------------
 
 test_that("lme4 anova works", {
+  skip_if(packageVersion("lme4") < "1.1.37")
   lme4 <- lme4::lmer(Reaction ~ Days + (1 | Subject), lme4::sleepstudy)
   model <- anova(lme4)
 
@@ -46,6 +50,7 @@ test_that("lme4 anova works", {
 })
 
 test_that("lme4 anova model comparison works", {
+  skip_if(packageVersion("lme4") < "1.1.37")
   lme4 <- lme4::lmer(Reaction ~ Days + (1 | Subject), lme4::sleepstudy)
   lme4_slopes <- lme4::lmer(
     Reaction ~ Days + (Days || Subject),

--- a/tests/testthat/test_lmerTest.R
+++ b/tests/testthat/test_lmerTest.R
@@ -5,6 +5,7 @@ expected_statistics <- read_stats("../data/lmerTest.json")
 # lmer() ------------------------------------------------------------------
 
 test_that("lmerTest 1 works", {
+  skip_if(packageVersion("lme4") < "1.1.37")
   model <- lmerTest::lmer(
     Reaction ~ Days + (Days | Subject), lme4::sleepstudy
   )
@@ -16,6 +17,7 @@ test_that("lmerTest 1 works", {
 })
 
 test_that("lmerTest 2 works", {
+  skip_if(packageVersion("lme4") < "1.1.37")
   model <- lmerTest::lmer(
     Informed.liking ~ Gender + Information * Product + (1 | Consumer) +
       (1 | Consumer:Product),
@@ -29,6 +31,7 @@ test_that("lmerTest 2 works", {
 })
 
 test_that("lmerTest ML works", {
+  skip_if(packageVersion("lme4") < "1.1.37")
   model <- lmerTest::lmer(
     Reaction ~ Days + (Days | Subject), sleepstudy,
     REML = FALSE
@@ -43,6 +46,7 @@ test_that("lmerTest ML works", {
 # anova.merMod() ----------------------------------------------------------
 
 test_that("lmerTest anova works", {
+  skip_if(packageVersion("lme4") < "1.1.37")
   m <- lmerTest::lmer(Reaction ~ Days + (Days | Subject), lme4::sleepstudy)
   model <- anova(m)
 
@@ -53,6 +57,7 @@ test_that("lmerTest anova works", {
 })
 
 test_that("lmerTest anova lme4 works", {
+  skip_if(packageVersion("lme4") < "1.1.37")
   m <- lmerTest::lmer(Reaction ~ Days + (Days | Subject), lme4::sleepstudy)
   model <- anova(m, ddf = "lme4")
 
@@ -63,6 +68,7 @@ test_that("lmerTest anova lme4 works", {
 })
 
 test_that("lmerTest anova fit works", {
+  skip_if(packageVersion("lme4") < "1.1.37")
   m0 <- lmerTest::lmer(Reaction ~ Days + (1 | Subject), sleepstudy)
   m <- lmerTest::lmer(Reaction ~ Days + (Days | Subject), sleepstudy)
   model <- anova(m0, m)


### PR DESCRIPTION
In https://github.com/lme4/lme4/commit/175615d91e9ccf833ef463bc80b430fea0e2f69e we changed the name of one of the elements of the summary output from "deviance" to "-2*log(L)", which is less confusing/more technically correct (since the value is *different* from what you get from `deviance(model)` ... this breaks something in tidystats that refers to `summary$AICtab[["deviance"]]`.

I tried to fix this, but am still having some trouble passing tests, even the ones I think should pass. Hopefully this PR should get you 90% of the way there ...

I'm planning to submit to CRAN later this week - do you think you will be able to push an updated version to CRAN in the near future (next few weeks)?

Sorry for the trouble, but labeling that value 'deviance' is really just wrong, we've been meaning to fix that for a while.
